### PR TITLE
Disable use of reduce function for view queries

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -51,7 +51,8 @@ Db.prototype.paginate = function (interval, startKey, endKey, pageSize, numPages
       startkey: key,
       startkey_docid: key_docid,
       limit: pageSize + 1,
-      include_docs: true
+      include_docs: true,
+      reduce: false
     };
 
     // unlike startkey/startkey_docid, null endkey/endkey_docid does not mean last document in the database

--- a/test/db.js
+++ b/test/db.js
@@ -16,6 +16,7 @@ buster.testCase('db - paginate', {
         assert.equals(opts.endkey, 'someendkey');
         assert.equals(opts.endkey_docid, 'someendkey');
         assert.isTrue(opts.include_docs);
+        assert.isFalse(opts.reduce);
         assert.equals(opts.limit, 3);
         assert.equals(opts.startkey, 'somestartkey');
         assert.equals(opts.startkey_docid, 'somestartkey');
@@ -34,6 +35,7 @@ buster.testCase('db - paginate', {
         assert.equals(opts.endkey, undefined);
         assert.equals(opts.endkey_docid, undefined);
         assert.isTrue(opts.include_docs);
+        assert.isFalse(opts.reduce);
         assert.equals(opts.limit, 3);
         assert.equals(opts.startkey, 'somestartkey');
         assert.equals(opts.startkey_docid, 'somestartkey');
@@ -49,6 +51,7 @@ buster.testCase('db - paginate', {
         assert.equals(opts.endkey, undefined);
         assert.equals(opts.endkey_docid, undefined);
         assert.isTrue(opts.include_docs);
+        assert.isFalse(opts.reduce);
         assert.equals(opts.limit, 3);
         assert.equals(opts.startkey, 'somestartkey');
         assert.equals(opts.startkey_docid, 'somestartkey');
@@ -62,6 +65,7 @@ buster.testCase('db - paginate', {
     var mockNano = {
       list: function (opts, cb) {
         assert.isTrue(opts.include_docs);
+        assert.isFalse(opts.reduce);
         assert.equals(opts.limit, 3);
         cb(null, { rows: [{ _id: 'someid1' }, { _id: 'someid2' }, { _id: 'someid3' }, { _id: 'someid4' }]});
       }


### PR DESCRIPTION
Couchtato fails to work for views with an associated reduce function. It exits with the following error:

```
`include_docs` is invalid for reduce
```

Since `include_docs` is always set to `true` the easy fix is to set `reduce` to `false`.